### PR TITLE
Runtime cpu detection

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -38,6 +38,7 @@ endif
 objarm = sha256_armv8_neon_x4.o\
 	sha256_armv8_neon_x1.o\
 	sha256_armv8_crypto.o\
+	hashtree.o\
 
 objx86 = sha256_shani.o\
 	sha256_avx_x16.o\
@@ -45,6 +46,7 @@ objx86 = sha256_shani.o\
 	sha256_avx_x4.o\
 	sha256_avx_x1.o\
 	sha256_sse_x1.o\
+	hashtree.o\
 
 .PHONY : clean
 

--- a/src/hashtree.c
+++ b/src/hashtree.c
@@ -1,0 +1,75 @@
+/*
+MIT License
+
+Copyright (c) 2021-2023 Prysmatic Labs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#include "hashtree.h"
+#ifdef __x86_64__
+#include <cpuid.h>
+#endif
+#ifdef __aarch64__
+#include <sys/auxv.h>
+#include <asm/hwcap.h>
+#endif
+
+void (*hash_ptr)(unsigned char*, const unsigned char*, uint64_t);
+
+void hashtree_init() {
+#ifdef __x86_64__
+    // Hard fail on processors that don't support SSE
+    hash_ptr = &sha256_1_sse;
+    uint32_t a,b,c,d; 
+    __get_cpuid_count(7,0,&a,&b,&c,&d);
+    if ((b & bit_AVX512F) && (b & bit_AVX512VL)) {
+        // Benchmarks show AVX512 performs better than Shani on larger lists
+        hash_ptr = &sha256_16_avx512;
+        return;
+    }
+    if (b & bit_SHA) {
+        hash_ptr = &sha256_shani;
+        return;
+    }
+    if (b & bit_AVX2) {
+        hash_ptr = &sha256_8_avx2;
+        return;
+    }
+    __get_cpuid_count(1,0,&a,&b,&c,&d);
+    if (c & bit_AVX) {
+        hash_ptr = &sha256_4_avx;
+        return;
+    }
+    hash_ptr = &sha256_1_sse;
+#endif
+#ifdef __aarch64__
+    // Hard fail on processors that don't support NEON
+    long hwcaps = getauxval(AT_HWCAP);
+    if (hwcaps & HWCAP_SHA2) {
+        hash_ptr = &sha256_armv8_crypto;
+        return;
+    }
+    hash_ptr = &sha256_armv8_neon_x4;
+#endif
+}
+
+void hash(unsigned char *output, const unsigned char *input, uint64_t count) {
+    (*hash_ptr)(output, input, count);
+}

--- a/src/hashtree.h
+++ b/src/hashtree.h
@@ -1,7 +1,7 @@
 /*
 MIT License
 
-Copyright (c) 2021 Prysmatic Labs
+Copyright (c) 2021-2023 Prysmatic Labs
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -24,6 +24,11 @@ SOFTWARE.
 #ifndef HASHTREE_H
 #define HASHTREE_H
 #include <stdint.h>
+
+void hashtree_init();
+
+// Undefined behavior if called before init()
+void hash(unsigned char *output, const unsigned char *input, uint64_t count);
 
 #ifdef __aarch64__
 void sha256_armv8_neon_x1(unsigned char* output, const unsigned char* input, uint64_t count);

--- a/src/test.c
+++ b/src/test.c
@@ -367,6 +367,19 @@ int digests_equal(const unsigned char* first, const unsigned char* second, unsig
     }
     return 1;
 }
+void test_hashtree_init() {
+    hashtree_init();
+}
+
+void test_hash() {
+    unsigned char digest[960];
+    hashtree_init();
+    hash(digest, test_32_block, 30);
+    TEST_CHECK(digests_equal(digest, test_32_digests, sizeof(digest)));
+    TEST_DUMP("Expected: ", test_32_digests, sizeof(digest));
+    TEST_DUMP("Produced: ", digest, sizeof(digest));
+}
+
 #ifdef __x86_64__
 void test_hash_sse_1() {
     unsigned char digest[32];
@@ -602,6 +615,8 @@ void test_hash_armv8_crypto_multiple_blocks() {
 
 
 TEST_LIST = {
+    {"hashtree_init", test_hashtree_init},
+    {"hash", test_hash},
 #ifdef HAVE_OPENSSL
     {"hash_openssl", test_hash_openssl}, 
 #endif


### PR DESCRIPTION
Exports two functions `void hashtree_init()` and `void hash(unsigned char*, const unsigned char*, uint64_t)` so that by calling the first one a function pointer is set that automatically detects the best implementation. Downstream can simply use the second function instead of choosing among the exported ones.

Note: benchmarks suggests that AVX512 is slightly faster than Shani on intel systems. I enabled this option. Overoptimizing systems may want to use shani for smaller trees instead of AVX512