### PR TITLE
Prepend hashtree name to functions

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,6 @@
+Language:        Cpp
+BasedOnStyle:  Google
+ColumnLimit:     120
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+IndentWidth:     4

--- a/src/bench.c
+++ b/src/bench.c
@@ -42,7 +42,7 @@ UBENCH_EX(armv8, neon_x1_one_at_time) {
     }
     UBENCH_DO_BENCHMARK() {
         for (int i = 0; i < buffer_size; i+=64) {
-            sha256_armv8_neon_x1(digest, (unsigned char *)(buffer+i/sizeof(int)), 1);
+            hashtree_sha256_neon_x1(digest, (unsigned char *)(buffer+i/sizeof(int)), 1);
         }
     }
     free(buffer);
@@ -55,7 +55,7 @@ UBENCH_EX(armv8, neon_x1) {
         buffer[i] = rand();
     }
     UBENCH_DO_BENCHMARK() {
-        sha256_armv8_neon_x1(digest, (unsigned char *)buffer, buffer_size/64);
+        hashtree_sha256_neon_x1(digest, (unsigned char *)buffer, buffer_size/64);
     }
     free(buffer);
     free(digest);
@@ -68,7 +68,7 @@ UBENCH_EX(armv8, neon_x4) {
         buffer[i] = rand();
     }
     UBENCH_DO_BENCHMARK() {
-        sha256_armv8_neon_x4(digest, (unsigned char *)buffer, buffer_size/64);
+        hashtree_sha256_neon_x4(digest, (unsigned char *)buffer, buffer_size/64);
     }
     free(buffer);
     free(digest);
@@ -81,7 +81,7 @@ UBENCH_EX(armv8, crypto) {
         buffer[i] = rand();
     }
     UBENCH_DO_BENCHMARK() {
-        sha256_armv8_crypto(digest, (unsigned char *)buffer, buffer_size/64);
+        hashtree_sha256_sha_x1(digest, (unsigned char *)buffer, buffer_size/64);
     }
     free(buffer);
     free(digest);
@@ -97,7 +97,7 @@ UBENCH_EX(sse, sse_x1_one_at_time) {
     }
     UBENCH_DO_BENCHMARK() {
         for (int i = 0; i < buffer_size; i+=64) {
-            sha256_1_sse(digest, (unsigned char *)(buffer+i/sizeof(int)), 1);
+            hashtree_sha256_sse_x1(digest, (unsigned char *)(buffer+i/sizeof(int)), 1);
         }
     }
     free(buffer);
@@ -110,7 +110,7 @@ UBENCH_EX(sse, sse_x1) {
         buffer[i] = rand();
     }
     UBENCH_DO_BENCHMARK() {
-        sha256_1_sse(digest, (unsigned char *)buffer, buffer_size/64);
+        hashtree_sha256_sse_x1(digest, (unsigned char *)buffer, buffer_size/64);
     }
     free(buffer);
     free(digest);
@@ -129,7 +129,7 @@ UBENCH_EX(avx, avx_x1_one_at_time) {
     }
     UBENCH_DO_BENCHMARK() {
         for (int i = 0; i < buffer_size; i+=64) {
-            sha256_1_avx(digest, (unsigned char *)(buffer+i/sizeof(int)), 1);
+            hashtree_sha256_avx_x1(digest, (unsigned char *)(buffer+i/sizeof(int)), 1);
         }
     }
     free(buffer);
@@ -148,7 +148,7 @@ UBENCH_EX(avx, avx_x1) {
         buffer[i] = rand();
     }
     UBENCH_DO_BENCHMARK() {
-        sha256_1_avx(digest, (unsigned char *)buffer, buffer_size/64);
+        hashtree_sha256_avx_x1(digest, (unsigned char *)buffer, buffer_size/64);
     }
     free(buffer);
     free(digest);
@@ -167,7 +167,7 @@ UBENCH_EX(avx, avx_x4) {
         buffer[i] = rand();
     }
     UBENCH_DO_BENCHMARK() {
-        sha256_4_avx(digest, (unsigned char *)buffer, buffer_size/64);
+        hashtree_sha256_avx_x4(digest, (unsigned char *)buffer, buffer_size/64);
     }
     free(buffer);
     free(digest);
@@ -186,7 +186,7 @@ UBENCH_EX(avx, avx_x8) {
         buffer[i] = rand();
     }
     UBENCH_DO_BENCHMARK() {
-        sha256_8_avx2(digest, (unsigned char *)buffer, buffer_size/64);
+        hashtree_sha256_avx2_x8(digest, (unsigned char *)buffer, buffer_size/64);
     }
     free(buffer);
     free(digest);
@@ -205,7 +205,7 @@ UBENCH_EX(avx, avx_x16) {
         buffer[i] = rand();
     }
     UBENCH_DO_BENCHMARK() {
-        sha256_16_avx512(digest, (unsigned char *)buffer, buffer_size/64);
+        hashtree_sha256_avx512_x16(digest, (unsigned char *)buffer, buffer_size/64);
     }
     free(buffer);
     free(digest);
@@ -224,7 +224,7 @@ UBENCH_EX(shani, shani) {
         buffer[i] = rand();
     }
     UBENCH_DO_BENCHMARK() {
-        sha256_shani(digest, (unsigned char *)buffer, buffer_size/64);
+        hashtree_sha256_shani_x2(digest, (unsigned char *)buffer, buffer_size/64);
     }
     free(buffer);
     free(digest);
@@ -243,7 +243,7 @@ UBENCH_EX(shani, shani_one_at_time) {
     }
     UBENCH_DO_BENCHMARK() {
         for (int i = 0; i < buffer_size; i+=64) {
-            sha256_shani(digest, (unsigned char *)(buffer+i/sizeof(int)), 1);
+            hashtree_sha256_shani_x2(digest, (unsigned char *)(buffer+i/sizeof(int)), 1);
         }
     }
     free(buffer);

--- a/src/hashtree.c
+++ b/src/hashtree.c
@@ -36,40 +36,40 @@ void (*hash_ptr)(unsigned char*, const unsigned char*, uint64_t);
 void hashtree_init() {
 #ifdef __x86_64__
     // Hard fail on processors that don't support SSE
-    hash_ptr = &sha256_1_sse;
+    hash_ptr = &hashtree_sha256_sse_x1;
     uint32_t a,b,c,d; 
     __get_cpuid_count(7,0,&a,&b,&c,&d);
     if ((b & bit_AVX512F) && (b & bit_AVX512VL)) {
         // Benchmarks show AVX512 performs better than Shani on larger lists
-        hash_ptr = &sha256_16_avx512;
+        hash_ptr = &hashtree_sha256_avx512_x16;
         return;
     }
     if (b & bit_SHA) {
-        hash_ptr = &sha256_shani;
+        hash_ptr = &hashtree_sha256_shani_x2;
         return;
     }
     if (b & bit_AVX2) {
-        hash_ptr = &sha256_8_avx2;
+        hash_ptr = &hashtree_sha256_avx2_x8;
         return;
     }
     __get_cpuid_count(1,0,&a,&b,&c,&d);
     if (c & bit_AVX) {
-        hash_ptr = &sha256_4_avx;
+        hash_ptr = &hashtree_sha256_avx_x4;
         return;
     }
-    hash_ptr = &sha256_1_sse;
+    hash_ptr = &hashtree_sha256_sse_x1;
 #endif
 #ifdef __aarch64__
     // Hard fail on processors that don't support NEON
     long hwcaps = getauxval(AT_HWCAP);
     if (hwcaps & HWCAP_SHA2) {
-        hash_ptr = &sha256_armv8_crypto;
+        hash_ptr = &hashtree_sha256_sha_x1;
         return;
     }
-    hash_ptr = &sha256_armv8_neon_x4;
+    hash_ptr = &hashtree_sha256_neon_x4;
 #endif
 }
 
-void hash(unsigned char *output, const unsigned char *input, uint64_t count) {
+void hashtree_hash(unsigned char *output, const unsigned char *input, uint64_t count) {
     (*hash_ptr)(output, input, count);
 }

--- a/src/hashtree.h
+++ b/src/hashtree.h
@@ -28,21 +28,20 @@ SOFTWARE.
 void hashtree_init();
 
 // Undefined behavior if called before init()
-void hash(unsigned char *output, const unsigned char *input, uint64_t count);
+void hashtree_hash(unsigned char* output, const unsigned char* input, uint64_t count);
 
 #ifdef __aarch64__
-void sha256_armv8_neon_x1(unsigned char* output, const unsigned char* input, uint64_t count);
-void sha256_armv8_neon_x4(unsigned char* output, const unsigned char* input, uint64_t count);
-void sha256_armv8_crypto(unsigned char *output, const unsigned char *input,
-                         uint64_t count);
+void hashtree_sha256_neon_x1(unsigned char* output, const unsigned char* input, uint64_t count);
+void hashtree_sha256_neon_x4(unsigned char* output, const unsigned char* input, uint64_t count);
+void hashtree_sha256_sha_x1(unsigned char* output, const unsigned char* input, uint64_t count);
 #endif 
 
 #ifdef __x86_64__
-void sha256_1_sse(unsigned char* output, const unsigned char* input, uint64_t count);
-void sha256_1_avx(unsigned char* output, const unsigned char* input, uint64_t count);
-void sha256_4_avx(unsigned char* output, const unsigned char* input, uint64_t count);
-void sha256_8_avx2(unsigned char* output, const unsigned char* input, uint64_t count);
-void sha256_16_avx512(unsigned char* output, const unsigned char* input, uint64_t count);
-void sha256_shani(unsigned char* output, const unsigned char* input, uint64_t count);
+void hashtree_sha256_sse_x1(unsigned char* output, const unsigned char* input, uint64_t count);
+void hashtree_sha256_avx_x1(unsigned char* output, const unsigned char* input, uint64_t count);
+void hashtree_sha256_avx_x4(unsigned char* output, const unsigned char* input, uint64_t count);
+void hashtree_sha256_avx2_x8(unsigned char* output, const unsigned char* input, uint64_t count);
+void hashtree_sha256_avx512_x16(unsigned char* output, const unsigned char* input, uint64_t count);
+void hashtree_sha256_shani_x2(unsigned char* output, const unsigned char* input, uint64_t count);
 #endif 
 #endif 

--- a/src/sha256_armv8_crypto.S
+++ b/src/sha256_armv8_crypto.S
@@ -67,10 +67,10 @@ padding .req x5
 		    hashupdate		\WORD
 .endm
 
-.global sha256_armv8_crypto
-.type sha256_armv8_crypto,%function
+.global hashtree_sha256_sha_x1
+.type hashtree_sha256_sha_x1,%function
 .align 5
-sha256_armv8_crypto:
+hashtree_sha256_sha_x1:
 		    // Set up stack, need to save the clobbered registers d8-d11
 		    sub			sp, sp, #32
 		    stp			d8, d9, [sp]

--- a/src/sha256_armv8_neon_x1.S
+++ b/src/sha256_armv8_neon_x1.S
@@ -299,10 +299,10 @@ T5 .req w22
 #   is writable.
 #
 ########################################################################################################
-.global sha256_armv8_neon_x1
-.type   sha256_armv8_neon_x1,%function
+.global hashtree_sha256_neon_x1
+.type   hashtree_sha256_neon_x1,%function
 .align 4
-sha256_armv8_neon_x1:
+hashtree_sha256_neon_x1:
 		    sub			sp, sp, #64
 		    stp			digest,k256, [sp, #48]
 		    

--- a/src/sha256_armv8_neon_x4.S
+++ b/src/sha256_armv8_neon_x4.S
@@ -277,10 +277,10 @@ TQ7		    .req q22
                     round_padding   \F, \G, \H, \A, \B, \C, \D, \E
 .endm
  
-.global sha256_armv8_neon_x4
-.type   sha256_armv8_neon_x4,%function
+.global hashtree_sha256_neon_x4
+.type   hashtree_sha256_neon_x4,%function
 .align 5
-sha256_armv8_neon_x4:
+hashtree_sha256_neon_x4:
                     sub                 sp, sp, #1024
 		    adr			k256, .LK256x4
 		    adr			padding, .LPADDINGx4
@@ -389,7 +389,7 @@ sha256_armv8_neon_x4:
                     b                   .Larmv8_neon_x4_loop                   
 .Lsha256_armv8_x4_epilog:
                     add                 sp, sp, #1024
-		    b			sha256_armv8_neon_x1
+		    b			hashtree_sha256_neon_x1
 
 .section .rodata
 .align 4

--- a/src/sha256_avx_x1.S
+++ b/src/sha256_avx_x1.S
@@ -404,12 +404,12 @@ rotate_Xs
 	ROTATE_ARGS
 .endm
 
-.global sha256_1_avx
+.global hashtree_sha256_avx_x1
 #ifndef __WIN64__
-.type   sha256_1_avx,%function
+.type   hashtree_sha256_avx_x1,%function
 #endif
 .align 32
-sha256_1_avx:
+hashtree_sha256_avx_x1:
         endbr64
 	push	rbx
 #ifdef __WIN64__
@@ -602,7 +602,7 @@ sha256_1_avx:
 
 	ret
 #ifdef __linux__ 
-.size sha256_1_avx,.-sha256_1_avx
+.size hashtree_sha256_avx_x1,.-hashtree_sha256_avx_x1
 .section .note.GNU-stack,"",@progbits
 #endif
 #endif

--- a/src/sha256_avx_x16.S
+++ b/src/sha256_avx_x16.S
@@ -955,12 +955,12 @@ Copied parts are
 	.long	0x0000000d, 0x0000000f, 0x0000001d, 0x0000001f
 
 .text
-.global sha256_16_avx512
+.global hashtree_sha256_avx512_x16
 #ifndef __WIN64__
-.type sha256_16_avx512,%function
+.type hashtree_sha256_avx512_x16,%function
 #endif
 .align 64
-sha256_16_avx512:
+hashtree_sha256_avx512_x16:
         endbr64
         cmp     COUNT, 0
         jne     .Lstart_routine
@@ -975,7 +975,7 @@ sha256_16_avx512:
 .set .Lpadding, 0
 	
 	cmp		COUNT, 16
-	jb		sha256_8_avx2
+	jb		hashtree_sha256_avx2_x8
 	
 	# Load pre-transposed digest
 	vmovdqa32	A, [DIGEST + 0*64]
@@ -1171,7 +1171,7 @@ sha256_16_avx512:
 	jmp		.Lsha256_16_avx512loop
 
 #ifdef __linux__ 
-.size sha256_16_avx512,.-sha256_16_avx512
+.size hashtree_sha256_avx512_x16,.-hashtree_sha256_avx512_x16
 .section .note.GNU-stack,"",@progbits
 #endif
 	

--- a/src/sha256_avx_x4.S
+++ b/src/sha256_avx_x4.S
@@ -343,12 +343,12 @@ Copied parts are
 .endm
 
 .text 
-.global sha256_4_avx
+.global hashtree_sha256_avx_x4
 #ifndef __WIN64__
-.type   sha256_4_avx,%function
+.type   hashtree_sha256_avx_x4,%function
 #endif
 .align 16
-sha256_4_avx:
+hashtree_sha256_avx_x4:
         endbr64
 	cmp	NUM_BLKS, 0
 	jne	.Lstart_routine
@@ -512,9 +512,9 @@ sha256_4_avx:
 #endif 
 
 	add	rsp, sha256_avx_4_stack_size
-        jmp     sha256_1_avx
+        jmp     hashtree_sha256_avx_x1
 #ifdef __linux__ 
-.size sha256_4_avx,.-sha256_4_avx
+.size hashtree_sha256_avx_x4,.-hashtree_sha256_avx_x4
 .section .note.GNU-stack,"",@progbits
 #endif
 #endif

--- a/src/sha256_avx_x8.S
+++ b/src/sha256_avx_x8.S
@@ -577,12 +577,12 @@ Copied parts are
 .endm
 
 .text
-.global sha256_8_avx2
+.global hashtree_sha256_avx2_x8
 #ifndef __WIN64__
-.type   sha256_8_avx2,%function
+.type   hashtree_sha256_avx2_x8,%function
 #endif
 .align 16
-sha256_8_avx2:
+hashtree_sha256_avx2_x8:
         endbr64
         cmp     NUM_BLKS, 0
         jne     .Lstart_routine
@@ -775,10 +775,10 @@ sha256_8_avx2:
 
 	mov     rsp,rbp
 	pop     rbp
-        jmp     sha256_4_avx
+        jmp     hashtree_sha256_avx_x4
 
 #ifdef __linux__ 
-.size sha256_8_avx2,.-sha256_8_avx2
+.size hashtree_sha256_avx2_x8,.-hashtree_sha256_avx2_x8
 .section .note.GNU-stack,"",@progbits
 #endif
 #endif

--- a/src/sha256_shani.S
+++ b/src/sha256_shani.S
@@ -107,12 +107,12 @@ SOFTWARE.
 .equiv MSGTMP4b,	xmm15
 
 .text 
-.global sha256_shani
+.global hashtree_sha256_shani_x2
 #ifndef __WIN64__
-.type   sha256_shani,%function
+.type   hashtree_sha256_shani_x2,%function
 #endif
 .align 16
-sha256_shani:
+hashtree_sha256_shani_x2:
 	sub		rsp, frame_size
 #ifdef __WIN64__
 	movdqa		[rsp + 0*16], xmm6

--- a/src/sha256_sse_x1.S
+++ b/src/sha256_sse_x1.S
@@ -362,12 +362,12 @@ rotate_Xs
 .endm
 
 .text
-.global sha256_1_sse
+.global hashtree_sha256_sse_x1
 #ifndef __WIN64__
-.type sha256_1_sse,%function
+.type hashtree_sha256_sse_x1,%function
 #endif
 .align 32
-sha256_1_sse:
+hashtree_sha256_sse_x1:
 	push	rbx
 #ifdef __WIN64__
         push    r8
@@ -560,7 +560,7 @@ sha256_1_sse:
 
 	ret
 #ifdef __linux__ 
-.size sha256_1_sse,.-sha256_1_sse
+.size hashtree_sha256_sse_x1,.-hashtree_sha256_sse_x1
 .section .note.GNU-stack,"",@progbits
 #endif
 #endif

--- a/src/test.c
+++ b/src/test.c
@@ -374,7 +374,7 @@ void test_hashtree_init() {
 void test_hash() {
     unsigned char digest[960];
     hashtree_init();
-    hash(digest, test_32_block, 30);
+    hashtree_hash(digest, test_32_block, 30);
     TEST_CHECK(digests_equal(digest, test_32_digests, sizeof(digest)));
     TEST_DUMP("Expected: ", test_32_digests, sizeof(digest));
     TEST_DUMP("Produced: ", digest, sizeof(digest));
@@ -383,14 +383,14 @@ void test_hash() {
 #ifdef __x86_64__
 void test_hash_sse_1() {
     unsigned char digest[32];
-    sha256_1_sse(digest, test_16_block, 1);
+    hashtree_sha256_sse_x1(digest, test_16_block, 1);
     TEST_ASSERT(sizeof(digest) == sizeof(test_1_digest));
     TEST_ASSERT(digests_equal(digest, test_1_digest, sizeof(digest)));
 }
 
 void test_hash_sse_x1_multiple_blocks() {
     unsigned char digest[256];
-    sha256_1_sse(digest, test_16_block, 8);
+    hashtree_sha256_sse_x1(digest, test_16_block, 8);
     TEST_ASSERT(digests_equal(digest, test_16_digests, sizeof(digest)));
 }
 
@@ -399,7 +399,7 @@ void test_hash_avx_1() {
     __get_cpuid_count(1,0,&a,&b,&c,&d);
     if (c & bit_AVX) {
         unsigned char digest[32];
-        sha256_1_avx(digest, test_16_block, 1);
+        hashtree_sha256_avx_x1(digest, test_16_block, 1);
         TEST_ASSERT(sizeof(digest) == sizeof(test_1_digest));
         TEST_ASSERT(digests_equal(digest, test_1_digest, sizeof(digest)));
     } else {
@@ -412,7 +412,7 @@ void test_hash_avx_x1_multiple_blocks() {
     __get_cpuid_count(1,0,&a,&b,&c,&d);
     if (c & bit_AVX) {
         unsigned char digest[256];
-        sha256_1_avx(digest, test_16_block, 8);
+        hashtree_sha256_avx_x1(digest, test_16_block, 8);
         TEST_ASSERT(digests_equal(digest, test_16_digests, sizeof(digest)));
     } else {
         acutest_colored_printf_(ACUTEST_COLOR_GREEN_INTENSIVE_, "[ CPU does not support AVX ]\n");
@@ -424,7 +424,7 @@ void test_hash_avx_4() {
     __get_cpuid_count(1,0,&a,&b,&c,&d);
     if (c & bit_AVX) {
         unsigned char digest[256];
-        sha256_4_avx(digest, test_16_block, 8);
+        hashtree_sha256_avx_x4(digest, test_16_block, 8);
 
         TEST_CHECK(digests_equal(digest, test_16_digests, sizeof(digest)));
         TEST_DUMP("Expected: ", test_16_digests, sizeof(digest));
@@ -441,7 +441,7 @@ void test_hash_avx_4_6_blocks() {
     if (c & bit_AVX) {
 
         unsigned char digest[192];
-        sha256_4_avx(digest, test_16_block, 6);
+        hashtree_sha256_avx_x4(digest, test_16_block, 6);
 
         TEST_CHECK(digests_equal(digest, test_16_digests, sizeof(digest)));
         TEST_DUMP("Expected: ", test_16_digests, sizeof(digest));
@@ -456,7 +456,7 @@ void test_hash_avx_8() {
     __get_cpuid_count(7,0,&a,&b,&c,&d);
     if (b & bit_AVX2) {
         unsigned char digest[512];
-        sha256_8_avx2(digest, test_16_block, 16);
+        hashtree_sha256_avx2_x8(digest, test_16_block, 16);
         TEST_CHECK(digests_equal(digest, test_16_digests, sizeof(digest)));
         TEST_DUMP("Expected: ", test_16_digests, sizeof(digest));
         TEST_DUMP("Produced: ", digest, sizeof(digest));
@@ -470,7 +470,7 @@ void test_hash_avx_8_13_blocks() {
     __get_cpuid_count(7,0,&a,&b,&c,&d);
     if (b & bit_AVX2) {
         unsigned char digest[416];
-        sha256_8_avx2(digest, test_16_block, 13);
+        hashtree_sha256_avx2_x8(digest, test_16_block, 13);
 
         TEST_CHECK(digests_equal(digest, test_16_digests, sizeof(digest)));
         TEST_DUMP("Expected: ", test_16_digests, sizeof(digest));
@@ -485,7 +485,7 @@ void test_hash_shani() {
     __get_cpuid_count(7,0,&a,&b,&c,&d);
     if (b & bit_SHA) {
         unsigned char digest[512];
-        sha256_shani(digest, test_16_block, 16);
+        hashtree_sha256_shani_x2(digest, test_16_block, 16);
         TEST_CHECK(digests_equal(digest, test_16_digests, sizeof(digest)));
         TEST_DUMP("Expected: ", test_16_digests, sizeof(digest));
         TEST_DUMP("Produced: ", digest, sizeof(digest));
@@ -499,7 +499,7 @@ void test_hash_shani_13_blocks() {
     __get_cpuid_count(7,0,&a,&b,&c,&d);
     if (b & bit_SHA) {
         unsigned char digest[416];
-        sha256_shani(digest, test_16_block, 13);
+        hashtree_sha256_shani_x2(digest, test_16_block, 13);
 
         TEST_CHECK(digests_equal(digest, test_16_digests, sizeof(digest)));
         TEST_DUMP("Expected: ", test_16_digests, sizeof(digest));
@@ -514,7 +514,7 @@ void test_hash_avx_16() {
     __get_cpuid_count(7,0,&a,&b,&c,&d);
     if ((b & bit_AVX512F) && (b & bit_AVX512VL)) {
         unsigned char digest[1024];
-        sha256_16_avx512(digest, test_32_block, 32);
+        hashtree_sha256_avx512_x16(digest, test_32_block, 32);
         TEST_CHECK(digests_equal(digest, test_32_digests, sizeof(digest)));
         TEST_DUMP("Expected: ", test_32_digests, sizeof(digest));
         TEST_DUMP("Produced: ", digest, sizeof(digest));
@@ -528,7 +528,7 @@ void test_hash_avx512_30_blocks() {
     __get_cpuid_count(7,0,&a,&b,&c,&d);
     if ((b & bit_AVX512F) && (b & bit_AVX512VL)) {
         unsigned char digest[960];
-        sha256_16_avx512(digest, test_32_block, 30);
+        hashtree_sha256_avx512_x16(digest, test_32_block, 30);
 
         TEST_CHECK(digests_equal(digest, test_32_digests, sizeof(digest)));
         TEST_DUMP("Expected: ", test_32_digests, sizeof(digest));
@@ -561,7 +561,7 @@ void test_hash_openssl() {
 void test_hash_armv8_neon_x1_one_block() {
     unsigned char digest[32];
 
-    sha256_armv8_neon_x1(digest, test_16_block, 1);
+    hashtree_sha256_neon_x1(digest, test_16_block, 1);
 
     TEST_CHECK(digests_equal(digest, test_1_digest, sizeof(digest)));
     TEST_DUMP("Expected: ", test_1_digest, sizeof(test_1_digest));
@@ -571,7 +571,7 @@ void test_hash_armv8_neon_x1_one_block() {
 void test_hash_armv8_neon_x1_multiple_blocks() {
     unsigned char digest[128];
 
-    sha256_armv8_neon_x1(digest, test_16_block, 4);
+    hashtree_sha256_neon_x1(digest, test_16_block, 4);
 
     TEST_CHECK(sizeof(digest) == sizeof(test_4_digests));
     TEST_MSG("Expected: %lu", sizeof(test_4_digests));
@@ -585,7 +585,7 @@ void test_hash_armv8_neon_x1_multiple_blocks() {
 void test_armv8_neon_x4() {
     unsigned char digest[256];
 
-    sha256_armv8_neon_x4(digest, test_16_block, 8);
+    hashtree_sha256_neon_x4(digest, test_16_block, 8);
 
     TEST_CHECK(digests_equal(digest, test_16_digests, sizeof(digest)));
     TEST_DUMP("Expected: ", test_16_digests, sizeof(digest));
@@ -597,7 +597,7 @@ void test_hash_armv8_crypto_multiple_blocks() {
     if (hwcaps & HWCAP_SHA2) {
     unsigned char digest[128];
 
-    sha256_armv8_crypto(digest, test_16_block, 4);
+    hashtree_sha256_sha_x1(digest, test_16_block, 4);
 
     TEST_CHECK(sizeof(digest) == sizeof(test_4_digests));
     TEST_MSG("Expected: %lu", sizeof(test_4_digests));


### PR DESCRIPTION
Fixes #1 
cc: @arnetheduck

Renames the exported symbols to be prepended by `hashtree_` 