### PR TITLE
Add install target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,3 +13,8 @@ bench:
 all:
 	$(MAKE) -C src all
 
+install:
+	$(MAKE) -C src install
+
+uninstall:
+	$(MAKE) -C src uninstall

--- a/src/FindHashtree.cmake
+++ b/src/FindHashtree.cmake
@@ -1,0 +1,51 @@
+#[=======================================================================[.rst:
+FindHashtree
+-----------
+
+Find the Hashtree library
+
+IMPORTED targets
+^^^^^^^^^^^^^^^^
+
+This module defines the following :prop_tgt:`IMPORTED` target:
+
+``Hashtree::Hashtree``
+
+Result variables
+^^^^^^^^^^^^^^^^
+
+This module will set the following variables if found:
+
+``Hashtree_INCLUDE_DIRS``
+  where to find hashtree.h
+``Hashtree_LIBRARIES``
+  the libraries to link against to use Hashtree.
+``Hashtree_FOUND``
+  TRUE if found
+
+#]=======================================================================]
+
+# Look for the necessary header
+find_path(Hashtree_INCLUDE_DIR NAMES hashtree.h)
+mark_as_advanced(Hashtree_INCLUDE_DIR)
+
+# Look for the necessary library
+find_library(Hashtree_LIBRARY NAMES hashtree)
+mark_as_advanced(Hashtree_LIBRARY)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Hashtree
+	REQUIRED_VARS Hashtree_INCLUDE_DIR Hashtree_LIBRARY
+)
+
+# Create the imported target
+if(Hashtree_FOUND)
+    set(Hashtree_INCLUDE_DIRS ${Hashtree_INCLUDE_DIR})
+    set(Hashtree_LIBRARIES ${Hashtree_LIBRARY})
+    if(NOT TARGET Hashtree::Hashtree)
+        add_library(Hashtree::Hashtree UNKNOWN IMPORTED)
+        set_target_properties(Hashtree::Hashtree PROPERTIES
+            IMPORTED_LOCATION             "${Hashtree_LIBRARY}"
+            INTERFACE_INCLUDE_DIRECTORIES "${Hashtree_INCLUDE_DIR}")
+    endif()
+endif()

--- a/src/Makefile
+++ b/src/Makefile
@@ -23,6 +23,8 @@
 ARM = $(shell $(CC) -dM -E - < /dev/null | grep "aarch" | awk '{ print $$3 }')
 WIN = $(shell $(CC) -dM -E - < /dev/null | grep "__WIN64__" | awk '{ print $$3 }')
 
+VERSION := 0.0.1-alpha
+
 ASFLAGS += -g -fpic
 CFLAGS +=  -g -Wall -Werror
 LDFLAGS += -L .
@@ -48,7 +50,8 @@ objx86 = sha256_shani.o\
 	sha256_sse_x1.o\
 	hashtree.o\
 
-.PHONY : clean
+.PHONY : clean .FORCE
+.FORCE: 
 
 ifeq ($(WIN),1)
 libname = libhashtree.lib
@@ -57,10 +60,10 @@ libname = libhashtree.a
 endif
 
 ifeq ($(ARM),1)
-libhashtree.a: $(objarm)
+libhashtree.a: $(objarm) hashtree.pc
 	$(AR) rcs libhashtree.a $(objarm)
 else
-$(libname): $(objx86)
+$(libname): $(objx86) hashtree.pc
 	$(AR) rcs $(libname) $(objx86)
 endif
 
@@ -73,4 +76,35 @@ bench: hashtree.h ubench.h bench.c $(libname)
 	$(CC) $(CFLAGS) $(LDFLAGS) -o bench bench.c $(benchlibs)
 
 clean:
-	-rm -f $(objarm) $(objx86) libhashtree.a libhashtree.lib test test.exe bench 
+	-rm -f $(objarm) $(objx86) libhashtree.a libhashtree.lib test test.exe bench hashtree.pc
+
+ifeq ($(PREFIX),)
+PREFIX := /usr
+endif
+
+hashtree.pc: .FORCE
+	@echo 'prefix='$(PREFIX) >> hashtree.pc
+	@echo 'exec_prefix=$${prefix}' >> hashtree.pc
+	@echo 'libdir=$${prefix}/lib' >> hashtree.pc
+	@echo 'includedir=$${prefix}/include' >> hashtree.pc
+	@echo '' >> hashtree.pc
+	@echo 'Name: hashtree' >> hashtree.pc
+	@echo 'Description: Fast hashing of Merkle trees' >> hashtree.pc
+	@echo 'Version: '$(VERSION) >> hashtree.pc
+	@echo 'LIBS: -L$${libdir} -lhashtree' >> hashtree.pc
+	@echo 'Cflags: -I$${includedir}'>> hashtree.pc
+
+ifneq ($(WIN),1)
+install: libhashtree.a hashtree.pc
+	install -d $(DESTDIR)$(PREFIX)/lib
+	install -m 644 libhashtree.a $(DESTDIR)$(PREFIX)/lib/ 
+	install -d $(DESTDIR)$(PREFIX)/include
+	install -m 644 hashtree.h $(DESTDIR)$(PREFIX)/include/
+	install -d $(DESTDIR)$(PREFIX)/lib/pkgconfig
+	install -m 644 hashtree.pc $(DESTDIR)$(PREFIX)/lib/pkgconfig/hashtree.pc
+
+uninstall: libhashtree.a
+	rm $(DESTDIR)$(PREFIX)/lib/libhashtree.a
+	rm $(DESTDIR)$(PREFIX)/include/hashtree.h
+endif
+

--- a/src/Makefile
+++ b/src/Makefile
@@ -91,6 +91,7 @@ hashtree.pc: .FORCE
 	@echo 'Name: hashtree' >> hashtree.pc
 	@echo 'Description: Fast hashing of Merkle trees' >> hashtree.pc
 	@echo 'Version: '$(VERSION) >> hashtree.pc
+	@echo 'URL: https://github.com/prysmaticlabs/hashtree' >> hashtree.pc
 	@echo 'LIBS: -L$${libdir} -lhashtree' >> hashtree.pc
 	@echo 'Cflags: -I$${includedir}'>> hashtree.pc
 

--- a/src/hashtree.h
+++ b/src/hashtree.h
@@ -26,8 +26,11 @@ SOFTWARE.
 
 #include <stdint.h>
 
-typedef void (*hashtree_hash_fcn)(unsigned char*, const unsigned char*, uint64_t);
+#ifdef __cplusplus
+extern "C" {
+#endif
 
+typedef void (*hashtree_hash_fcn)(unsigned char*, const unsigned char*, uint64_t);
 
 /** Initialize the library to use the given hash tree function or perform
  * auto-detection based on the CPU if `NULL` is given.
@@ -53,4 +56,7 @@ void hashtree_sha256_avx2_x8(unsigned char* output, const unsigned char* input, 
 void hashtree_sha256_avx512_x16(unsigned char* output, const unsigned char* input, uint64_t count);
 void hashtree_sha256_shani_x2(unsigned char* output, const unsigned char* input, uint64_t count);
 #endif
+#ifdef __cplusplus
+}
 #endif
+#endif 


### PR DESCRIPTION
This PR adds an install makefile target, a pkgfile and a cmake find package file. This only works on linux at the moment. 

It also wraps an extern "C" file to make the header it work under c++ linkers without the caller needing to do so. 