### PR TITLE
Use normal equate for missing var

### DIFF
--- a/src/sha256_sse_x1.S
+++ b/src/sha256_sse_x1.S
@@ -128,7 +128,7 @@ Copied parts are
 .equ f, r9d
 .equ g, r10d
 .equ h, r11d
-.equiv e, r12d
+.equ e, r12d
 
 .equiv y0, r13d
 .equiv y1, r14d


### PR DESCRIPTION
Updating to
```
$ gcc --version
gcc (GCC) 13.2.1 20230801
$ as --version
GNU assembler (GNU Binutils) 2.41.0
```
Breaks assembly of sha256_sse_x1.S