### PR TITLE
Initialize explicitly cpuid variables in tests

### DIFF
--- a/src/bench.c
+++ b/src/bench.c
@@ -117,7 +117,7 @@ UBENCH_EX(sse, sse_x1) {
 }
 
 UBENCH_EX(avx, avx_x1_one_at_time) {
-    uint32_t a,b,c,d; 
+    uint32_t a = 0, b = 0, c = 0, d = 0;
     __get_cpuid_count(1,0,&a,&b,&c,&d);
     if (!(c & bit_AVX)) {
       return;
@@ -136,7 +136,7 @@ UBENCH_EX(avx, avx_x1_one_at_time) {
 }
 
 UBENCH_EX(avx, avx_x1) {
-    uint32_t a,b,c,d; 
+    uint32_t a = 0, b = 0, c = 0, d = 0;
     __get_cpuid_count(1,0,&a,&b,&c,&d);
     if (!(c & bit_AVX)) {
       return;
@@ -155,7 +155,7 @@ UBENCH_EX(avx, avx_x1) {
 }
 
 UBENCH_EX(avx, avx_x4) {
-    uint32_t a,b,c,d; 
+    uint32_t a = 0, b = 0, c = 0, d = 0;
     __get_cpuid_count(1,0,&a,&b,&c,&d);
     if (!(c & bit_AVX)) {
       return;
@@ -174,7 +174,7 @@ UBENCH_EX(avx, avx_x4) {
 }
 
 UBENCH_EX(avx, avx_x8) {
-    uint32_t a,b,c,d; 
+    uint32_t a = 0, b = 0, c = 0, d = 0;
     __get_cpuid_count(7,0,&a,&b,&c,&d);
     if (!(b & bit_AVX2)) {
       return;
@@ -193,7 +193,7 @@ UBENCH_EX(avx, avx_x8) {
 }
 
 UBENCH_EX(avx, avx_x16) {
-    uint32_t a,b,c,d; 
+    uint32_t a = 0, b = 0, c = 0, d = 0;
     __get_cpuid_count(7,0,&a,&b,&c,&d);
     if (!(b & bit_AVX512F) || !(b & bit_AVX512VL)) {
       return;
@@ -212,7 +212,7 @@ UBENCH_EX(avx, avx_x16) {
 }
 
 UBENCH_EX(shani, shani) {
-    uint32_t a,b,c,d; 
+    uint32_t a = 0, b = 0, c = 0, d = 0;
     __get_cpuid_count(7,0,&a,&b,&c,&d);
     if (!(b & bit_SHA)) {
       return;
@@ -231,7 +231,7 @@ UBENCH_EX(shani, shani) {
 }
 
 UBENCH_EX(shani, shani_one_at_time) {
-    uint32_t a,b,c,d; 
+    uint32_t a = 0, b = 0, c = 0, d = 0;
     __get_cpuid_count(7,0,&a,&b,&c,&d);
     if (!(b & bit_SHA)) {
       return;

--- a/src/test.c
+++ b/src/test.c
@@ -391,7 +391,7 @@ void test_hash_sse_x1_multiple_blocks() {
 }
 
 void test_hash_avx_1() {
-    uint32_t a,b,c,d;
+    uint32_t a = 0, b = 0, c = 0, d = 0;
     __get_cpuid_count(1,0,&a,&b,&c,&d);
     if (c & bit_AVX) {
         unsigned char digest[32];
@@ -404,7 +404,7 @@ void test_hash_avx_1() {
 }
 
 void test_hash_avx_x1_multiple_blocks() {
-    uint32_t a,b,c,d;
+    uint32_t a = 0, b = 0, c = 0, d = 0;
     __get_cpuid_count(1,0,&a,&b,&c,&d);
     if (c & bit_AVX) {
         unsigned char digest[256];
@@ -416,7 +416,7 @@ void test_hash_avx_x1_multiple_blocks() {
 }
 
 void test_hash_avx_4() {
-    uint32_t a,b,c,d;
+    uint32_t a = 0, b = 0, c = 0, d = 0;
     __get_cpuid_count(1,0,&a,&b,&c,&d);
     if (c & bit_AVX) {
         unsigned char digest[256];
@@ -432,7 +432,7 @@ void test_hash_avx_4() {
 
 
 void test_hash_avx_4_6_blocks() {
-    uint32_t a,b,c,d;
+    uint32_t a = 0, b = 0, c = 0, d = 0;
     __get_cpuid_count(1,0,&a,&b,&c,&d);
     if (c & bit_AVX) {
 
@@ -448,7 +448,7 @@ void test_hash_avx_4_6_blocks() {
 }
 
 void test_hash_avx_8() {
-    uint32_t a,b,c,d;
+    uint32_t a = 0, b = 0, c = 0, d = 0;
     __get_cpuid_count(7,0,&a,&b,&c,&d);
     if (b & bit_AVX2) {
         unsigned char digest[512];
@@ -462,7 +462,7 @@ void test_hash_avx_8() {
 }
 
 void test_hash_avx_8_13_blocks() {
-    uint32_t a,b,c,d;
+    uint32_t a = 0, b = 0, c = 0, d = 0;
     __get_cpuid_count(7,0,&a,&b,&c,&d);
     if (b & bit_AVX2) {
         unsigned char digest[416];
@@ -477,7 +477,7 @@ void test_hash_avx_8_13_blocks() {
 }
 
 void test_hash_shani() {
-    uint32_t a,b,c,d;
+    uint32_t a = 0, b = 0, c = 0, d = 0;
     __get_cpuid_count(7,0,&a,&b,&c,&d);
     if (b & bit_SHA) {
         unsigned char digest[512];
@@ -491,7 +491,7 @@ void test_hash_shani() {
 }
 
 void test_hash_shani_13_blocks() {
-    uint32_t a,b,c,d;
+    uint32_t a = 0, b = 0, c = 0, d = 0;
     __get_cpuid_count(7,0,&a,&b,&c,&d);
     if (b & bit_SHA) {
         unsigned char digest[416];
@@ -506,7 +506,7 @@ void test_hash_shani_13_blocks() {
 }
 
 void test_hash_avx_16() {
-    uint32_t a,b,c,d;
+    uint32_t a = 0, b = 0, c = 0, d = 0;
     __get_cpuid_count(7,0,&a,&b,&c,&d);
     if ((b & bit_AVX512F) && (b & bit_AVX512VL)) {
         unsigned char digest[1024];
@@ -520,7 +520,7 @@ void test_hash_avx_16() {
 }
 
 void test_hash_avx512_30_blocks() {
-    uint32_t a,b,c,d;
+    uint32_t a = 0, b = 0, c = 0, d = 0;
     __get_cpuid_count(7,0,&a,&b,&c,&d);
     if ((b & bit_AVX512F) && (b & bit_AVX512VL)) {
         unsigned char digest[960];


### PR DESCRIPTION
[Issue](https://github.com/prysmaticlabs/hashtree/pull/21) was fixed for the module source code but for tests a problem is still relevant. This commit fixes it.

Follows up https://github.com/prysmaticlabs/hashtree/issues/20