### PR TITLE
Use 32 bit addressing on ARM

### DIFF
--- a/src/sha256_armv8_crypto.S
+++ b/src/sha256_armv8_crypto.S
@@ -74,11 +74,16 @@ hashtree_sha256_sha_x1:
 		    // Set up stack, need to save the clobbered registers d8-d11
 		    sub			sp, sp, #32
 		    stp			d8, d9, [sp]
-		    adr			digest, .LDIGEST
-		    adr			k256, .LK256
+		    adrp		digest, .LDIGEST
+		    add			digest, digest, #:lo12:.LDIGEST
+
+		    adrp		k256, .LK256
+		    add			k256, k256, #:lo12:.LK256
 
 		    stp			d10, d11, [sp, #16]
-		    adr			padding, .LPADDING
+		    adrp		padding, .LPADDING
+		    add			padding, padding, #:lo12:.LPADDING
+
 		    add			last, output, count, lsl #5
 
 		    ld1			{v0.4s, v1.4s}, [digest]

--- a/src/sha256_armv8_neon_x1.S
+++ b/src/sha256_armv8_neon_x1.S
@@ -308,8 +308,12 @@ hashtree_sha256_neon_x1:
 		    
 		    movi		VZ.4s, #0
                     stp                 padding, x22, [sp, #32]
-		    adr			digest, .LDIGEST 
-		    adr			padding, .LPADDING
+		    adrp		digest, .LDIGEST 
+		    add			digest, digest, #:lo12:.LDIGEST
+
+		    adrp		padding, .LPADDING
+		    add 		padding, padding, #:lo12:.LPADDING
+
 		    add			last, output, count, lsl #5
 
 .Lhash_1_block_loop:
@@ -318,7 +322,8 @@ hashtree_sha256_neon_x1:
                     beq                 .Larmv8_neon_x1_finish
                     
 		    ld1			{VR0.4s, VR1.4s, VR2.4s, VR3.4s}, [input], #64
-		    adr			k256, .LK256
+		    adrp		k256, .LK256
+		    add 		k256, k256, #:lo12:.LK256
 
 # change endianness
 		    rev32		VR0.16b, VR0.16b

--- a/src/sha256_armv8_neon_x4.S
+++ b/src/sha256_armv8_neon_x4.S
@@ -282,10 +282,18 @@ TQ7		    .req q22
 .align 5
 hashtree_sha256_neon_x4:
                     sub                 sp, sp, #1024
-		    adr			k256, .LK256x4
-		    adr			padding, .LPADDINGx4
-		    adr			digest, .LDIGESTx4L
-                    adr                 digest2, .LDIGESTx4H
+		    adrp		k256, .LK256x4
+		    add			k256, k256, #:lo12:.LK256x4
+
+		    adrp		padding, .LPADDINGx4
+		    add			padding, padding, #:lo12:.LPADDINGx4
+
+		    adrp		digest, .LDIGESTx4L
+		    add			digest, digest, #:lo12:.LDIGESTx4L
+
+		    adrp		digest2, .LDIGESTx4H
+		    add			digest2, digest2, #:lo12:.LDIGESTx4H
+
                     mov                 post64, #64
                     mov                 post32, #32
                     mov                 postminus80, #-80


### PR DESCRIPTION
Consumers of the library, if they insert a lot of data between text and .rodata may hit a relocation issue when linking. Rather than tweaking the linker, this PR fixes the addressing modes by adding a couple of cycles when loading symbols allowing them to be separated to 32 bits.

Fixes #28