### PR TITLE
Add GNU-stack tag to shani assembly

### DIFF
--- a/src/sha256_shani.S
+++ b/src/sha256_shani.S
@@ -974,4 +974,8 @@ hashtree_sha256_shani_x2:
 #endif
 	add		rsp, frame_size
 	ret	
+#ifdef __linux__ 
+.size hashtree_sha256_shani_x2,.-hashtree_sha256_shani_x2
+.section .note.GNU-stack,"",@progbits
+#endif
 #endif


### PR DESCRIPTION
This adds the proper missing tag to a remaining assembly file to stop the linker from complaining. Notice this tag is present on all other AMD assembly. 