### PR TITLE
Fix Apple clang bugs (incorrect SHA results on macOS 26.4)

### DIFF
--- a/src/sha256_armv8_crypto.S
+++ b/src/sha256_armv8_crypto.S
@@ -1,7 +1,7 @@
 /*
 MIT License
 
-Copyright (c) 2021-2024 Prysmatic Labs
+Copyright (c) 2021-2026 Prysmatic Labs
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/sha256_armv8_crypto.S
+++ b/src/sha256_armv8_crypto.S
@@ -205,7 +205,11 @@ hashtree_sha256_sha_x1:
 		    ldp			d10, d11, [sp], #16
 		    ret
 
+#ifdef __APPLE__
+.const
+#else
 .section .rodata, "a"
+#endif
 .align 4
 .LDIGEST:
 .word		    0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a,\

--- a/src/sha256_armv8_crypto.S
+++ b/src/sha256_armv8_crypto.S
@@ -87,9 +87,9 @@ hashtree_sha256_sha_x1:
 
 #ifdef __APPLE__
 		    adrp		digest, .LDIGEST@PAGE
-		    add			digest, digest, #:lo12:.LDIGEST@PAGEOFF
+		    add			digest, digest, .LDIGEST@PAGEOFF
 		    adrp		k256, .LK256@PAGE
-		    add			k256, k256, #:lo12:.LK256@PAGEOFF
+		    add			k256, k256, .LK256@PAGEOFF
 #else
 		    adrp		digest, .LDIGEST
 		    add			digest, digest, #:lo12:.LDIGEST
@@ -99,7 +99,7 @@ hashtree_sha256_sha_x1:
 		    stp			d10, d11, [sp, #16]
 #ifdef __APPLE__
 		    adrp		padding, .LPADDING@PAGE
-		    add			padding, padding, #:lo12:.LPADDING@PAGEOFF
+		    add			padding, padding, .LPADDING@PAGEOFF
 #else
 		    adrp		padding, .LPADDING
 		    add			padding, padding, #:lo12:.LPADDING

--- a/src/sha256_armv8_neon_x1.S
+++ b/src/sha256_armv8_neon_x1.S
@@ -338,7 +338,7 @@ hashtree_sha256_neon_x1:
 		    ld1			{VR0.4s, VR1.4s, VR2.4s, VR3.4s}, [input], #64
 #ifdef __APPLE__
 		    adrp		k256, .LK256@PAGE
-		    add 		k256, k256, #:lo12:.LK256@PAGEOFF
+		    add 		k256, k256, .LK256@PAGEOFF
 #else
 		    adrp		k256, .LK256
 		    add 		k256, k256, #:lo12:.LK256

--- a/src/sha256_armv8_neon_x1.S
+++ b/src/sha256_armv8_neon_x1.S
@@ -441,7 +441,11 @@ hashtree_sha256_neon_x1:
 		    add			sp, sp, #64
 		    ret
 
+#ifdef __APPLE__
+.const
+#else
 .section .rodata, "a"
+#endif
 .align 4
 .LDIGEST:
 .word		    0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a,\

--- a/src/sha256_armv8_neon_x1.S
+++ b/src/sha256_armv8_neon_x1.S
@@ -1,7 +1,7 @@
 /*
 MIT License
 
-Copyright (c) 2021-2024 Prysmatic Labs
+Copyright (c) 2021-2026 Prysmatic Labs
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/sha256_armv8_neon_x4.S
+++ b/src/sha256_armv8_neon_x4.S
@@ -297,14 +297,14 @@ hashtree_sha256_neon_x4:
                     sub                 sp, sp, #1024
 
 #ifdef __APPLE__
-		    adrp		k256,.LK256x4@GOTPAGE
-		    ldr			k256, [k256, .LK256x4@GOTPAGEOFF]
-		    adrp		padding, .LPADDINGx4@GOTPAGE
-		    ldr			padding, [padding, .LPADDINGx4@GOTPAGEOFF]
-		    adrp		digest, .LDIGESTx4L@GOTPAGE
-		    ldr			digest, [digest, .LDIGESTx4L@GOTPAGEOFF]
-		    adrp		digest2, .LDIGESTx4H@GOTPAGE
-		    ldr			digest2, [digest2, .LDIGESTx4H@GOTPAGEOFF]
+		    adrp		k256, .LK256x4@PAGE
+		    add			k256, k256, .LK256x4@PAGEOFF
+		    adrp		padding, .LPADDINGx4@PAGE
+		    add			padding, padding, .LPADDINGx4@PAGEOFF
+		    adrp		digest, .LDIGESTx4L@PAGE
+		    add			digest, digest, .LDIGESTx4L@PAGEOFF
+		    adrp		digest2, .LDIGESTx4H@PAGE
+		    add			digest2, digest2, .LDIGESTx4H@PAGEOFF
 #else
 		    adrp		k256,.LK256x4
 		    add			k256, k256, #:lo12:.LK256x4

--- a/src/sha256_armv8_neon_x4.S
+++ b/src/sha256_armv8_neon_x4.S
@@ -1,7 +1,7 @@
 /*
 MIT License
 
-Copyright (c) 2021-2024 Prysmatic Labs
+Copyright (c) 2021-2026 Prysmatic Labs
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -423,7 +423,11 @@ hashtree_sha256_neon_x4:
 #else
 		    b			hashtree_sha256_neon_x1
 #endif
+#ifdef __APPLE__
+.const
+#else
 .section .rodata,"a"
+#endif
 .align 4
 .LDIGESTx4L:
 .word		    0x6a09e667, 0x6a09e667, 0x6a09e667, 0x6a09e667,\


### PR DESCRIPTION
#30 attempted to "fix mac", but did so only partially. Interestingly, this used to work accidentally, but since macOS 26.4 they shipped a new Apple clang that randomly introduces UB when the code is wrong.

Open-source clang reports:

```
error: invalid variant on expression 'PAGEOFF' (already modified)
```

So, the problem is that _some_ instances of #30 left the `#:lo12:` ELF syntax in the `#ifdef __APPLE__` branches. Weirdly, not everywhere. Applying the correct syntax in all Apple branches fixes the problem.

macOS 26.4 Clang version:
```
% clang --version
Apple clang version 21.0.0 (clang-2100.0.123.102)
Target: arm64-apple-darwin25.4.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
```

Interestingly, the open-source clang starts failing with UNREACHABLE when asserts are on: https://github.com/llvm/llvm-project/issues/188764

So, maybe Apple clang has some weird build where asserts are disabled, and the resulting UB from UNREACHABLE then inhibits "already modified". But I could not reproduce the successful assembly + wrong results on open-source clang. The old clang (either OSS or Apple) just works fine. The new clang (OSS) either crashes with UNREACHABLE or raises error. The new Apple clang succeeds and then has wrong SHA results.

In any case, fixing the relocation syntax gets rid of the bugs.