### PR TITLE
riscv: fix hwprobe extension bit positions

### DIFF
--- a/src/hashtree.c
+++ b/src/hashtree.c
@@ -49,17 +49,22 @@ struct riscv_hwprobe {
 };
 
 #define RISCV_HWPROBE_KEY_IMA_EXT_0 4
-#define RISCV_HWPROBE_EXT_ZBB       (1ULL << 1)
-#define RISCV_HWPROBE_EXT_ZBC       (1ULL << 2)
-#define RISCV_HWPROBE_EXT_ZBKB      (1ULL << 3)
-#define RISCV_HWPROBE_EXT_ZBKC      (1ULL << 4)
-#define RISCV_HWPROBE_EXT_ZBKX      (1ULL << 5)
-#define RISCV_HWPROBE_EXT_ZKND      (1ULL << 6)
-#define RISCV_HWPROBE_EXT_ZKNE      (1ULL << 7)
-#define RISCV_HWPROBE_EXT_ZKNH      (1ULL << 8)
-#define RISCV_HWPROBE_EXT_ZKSED     (1ULL << 9)
-#define RISCV_HWPROBE_EXT_ZKSH      (1ULL << 10)
-#define RISCV_HWPROBE_EXT_ZKT       (1ULL << 11)
+/*
+ * Extension bit positions as defined by the Linux riscv_hwprobe ABI
+ * (arch/riscv/include/uapi/asm/hwprobe.h). The bits are not contiguous:
+ * bits 0-2 are the IMA FD/C/V flags and bit 3 is Zba, so Zbb starts at bit 4.
+ */
+#define RISCV_HWPROBE_EXT_ZBB       (1ULL << 4)
+#define RISCV_HWPROBE_EXT_ZBC       (1ULL << 7)
+#define RISCV_HWPROBE_EXT_ZBKB      (1ULL << 8)
+#define RISCV_HWPROBE_EXT_ZBKC      (1ULL << 9)
+#define RISCV_HWPROBE_EXT_ZBKX      (1ULL << 10)
+#define RISCV_HWPROBE_EXT_ZKND      (1ULL << 11)
+#define RISCV_HWPROBE_EXT_ZKNE      (1ULL << 12)
+#define RISCV_HWPROBE_EXT_ZKNH      (1ULL << 13)
+#define RISCV_HWPROBE_EXT_ZKSED     (1ULL << 14)
+#define RISCV_HWPROBE_EXT_ZKSH      (1ULL << 15)
+#define RISCV_HWPROBE_EXT_ZKT       (1ULL << 16)
 #endif
 
 static void init_and_hash(unsigned char *output, const unsigned char *input, uint64_t count);


### PR DESCRIPTION
The RISCV_HWPROBE_EXT_* constants used a dense 1<<1, 1<<2, ... enumeration, but the Linux riscv_hwprobe ABI (arch/riscv/include/uapi/asm/hwprobe.h) assigns non-contiguous bits: Zbb=1<<4, Zbkb=1<<8, Zknh=1<<13, etc.

In particular 1<<1 is RISCV_HWPROBE_IMA_C, which is always set on rv64gc, so Zbb was detected as present on every CPU and hashtree_sha256_riscv_zbb_x1 was selected even on cores without Zbb -- causing an illegal-instruction fault (rev8) on a base rv64gc core. The crypto path used similarly wrong bits.

Correct all the constants to match the kernel ABI. Verified with qemu-user 10.0.8: -cpu rv64,zbb=false now selects the scalar path (no crash), while zbb / zknh+zbkb correctly select the Zbb / crypto paths, all producing the expected SHA-256 digest.